### PR TITLE
🐛fix:  Login,info,modify,delete fix

### DIFF
--- a/src/main/java/com/dotori/dotori/controller/AuthController.java
+++ b/src/main/java/com/dotori/dotori/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.dotori.dotori.controller;
 
 import com.dotori.dotori.dto.AuthDTO;
+import com.dotori.dotori.dto.AuthSecurityDTO;
 import com.dotori.dotori.entity.Auth;
 import com.dotori.dotori.repository.AuthRepository;
 import com.dotori.dotori.service.AuthService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -90,22 +92,16 @@ public class AuthController {
 
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/info")
-    public String authInfo(Model model) {
-        log.info("info commin");
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String id = authentication.getName();
-        AuthDTO authDTO = authService.info(id);
-        model.addAttribute("auth", authDTO);
+    public String authInfo(@AuthenticationPrincipal AuthSecurityDTO authSecurityDTO, Model model) {
+        log.info("info coming");
+        model.addAttribute("auth", authSecurityDTO);
         return "auth/info";
     }
 
     //    @PreAuthorize("principal.username == #authDTO.id")        //이런 인증 절차가 아무것도 없어요ㅠㅠ
     @GetMapping("/modify")
-    public String updateGET(Model model) {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        String id = authentication.getName();
-        AuthDTO authDTO = authService.info(id);
-        model.addAttribute("auth", authDTO);
+    public String updateGET(@AuthenticationPrincipal AuthSecurityDTO authSecurityDTO, Model model) {
+        model.addAttribute("auth", authSecurityDTO);
         return "auth/modify";
     }
 

--- a/src/main/java/com/dotori/dotori/dto/AuthDTO.java
+++ b/src/main/java/com/dotori/dotori/dto/AuthDTO.java
@@ -34,6 +34,8 @@ public class AuthDTO {
     // DTO 파일을 통하여 Social 로그인 시 Auth Entity를 생성하는 메소드
     public Auth toEntity() {
         return Auth.builder()
+                .id(this.email)
+                .password("1234")
                 .nickName(this.nickName)
                 .email(this.email)
                 .provider(this.provider)

--- a/src/main/java/com/dotori/dotori/dto/AuthSecurityDTO.java
+++ b/src/main/java/com/dotori/dotori/dto/AuthSecurityDTO.java
@@ -4,42 +4,31 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
-
 
 @Getter
 @Setter
 @ToString
-public class AuthSecurityDTO extends User {
+public class AuthSecurityDTO extends User implements OAuth2User {
 
     private int aid;
     private String id;
-    private String password;
     private String nickName;
     private String email;
     private boolean social;
 
     private Map<String, Object> props;
-
-    public AuthSecurityDTO(int aid, String id, String password, String nickName, String email, boolean social, Collection<GrantedAuthority> authorities) {
-        super(id, password, authorities);
+    public AuthSecurityDTO(int aid, String id, String password, String nickName, String email, boolean social, Collection<? extends GrantedAuthority> authorities) {
+        super(id == null ? "" : id, password == null ? "" : password, authorities);
         this.aid = aid;
         this.id = id;
-        this.password = password;
         this.nickName = nickName;
         this.email = email;
         this.social = social;
-    }
-
-    @Override
-    public Collection<GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
     }
 
     @Override
@@ -61,4 +50,15 @@ public class AuthSecurityDTO extends User {
     public boolean isEnabled() {
         return true;
     }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return props;
+    }
+
+    @Override
+    public String getName() {
+        return id;
+    }
+
 }

--- a/src/main/java/com/dotori/dotori/security/CustomUserDetailsService.java
+++ b/src/main/java/com/dotori/dotori/security/CustomUserDetailsService.java
@@ -50,7 +50,6 @@ public class CustomUserDetailsService implements UserDetailsService {
                 auth.getEmail(),
                 false,
                 Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
-
         );
 
         log.info("userSecurityDTO : {}", authSecurityDTO);

--- a/src/main/java/com/dotori/dotori/service/OAuth2Service.java
+++ b/src/main/java/com/dotori/dotori/service/OAuth2Service.java
@@ -1,6 +1,7 @@
 package com.dotori.dotori.service;
 
 import com.dotori.dotori.dto.AuthDTO;
+import com.dotori.dotori.dto.AuthSecurityDTO;
 import com.dotori.dotori.entity.Auth;
 import com.dotori.dotori.entity.OAuthAttributes;
 import com.dotori.dotori.repository.AuthRepository;
@@ -40,20 +41,22 @@ public class OAuth2Service implements OAuth2UserService<OAuth2UserRequest, OAuth
 
         Map<String, Object> attributes = oAuth2User.getAttributes();
 
+
         AuthDTO authDTO = OAuthAttributes.extract(registrationId, attributes);
         authDTO.setProvider(registrationId);
 
-        updateOrSaveUser(authDTO);
+        Auth auth = updateOrSaveUser(authDTO);
 
-        Map<String, Object> customAttribute =
-                getCustomAttribute(registrationId, userNameAttributeName, attributes, authDTO);
-
-        return new DefaultOAuth2User(
-                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
-                customAttribute,
-                userNameAttributeName);
+        return (OAuth2User) new AuthSecurityDTO(
+                auth.getAid(),
+                auth.getId(),
+                auth.getPassword(),
+                auth.getNickName(),
+                auth.getEmail(),
+                auth.isSocial(),
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"))
+        );
     }
-
     public Map getCustomAttribute(String registrationId,
                                   String userNameAttributeName,
                                   Map<String, Object> attributes,

--- a/src/main/resources/templates/auth/Info.html
+++ b/src/main/resources/templates/auth/Info.html
@@ -21,22 +21,22 @@
     <hr>
     <div class="input-group mb-3">
         <span class="input-group-text">아이디</span>
-        <input type="text" th:value="${auth.id}" name="id" class="form-control" readonly>
+        <input type="text" th:value="${#authentication.principal.id}" name="id" class="form-control" readonly>
     </div>
 
     <div class="input-group mb-3">
         <span class="input-group-text">패스워드</span>
-        <input type="password" th:value="${auth.password}" name="password" class="form-control" readonly>
+        <input type="password" th:value="${#authentication.principal.password}" name="password" class="form-control" readonly>
     </div>
 
     <div class="input-group mb-3">
         <span class="input-group-text">닉네임</span>
-        <input type="text" th:value="${auth.nickName}" name="nickName" class="form-control" readonly>
+        <input type="text" th:value="${#authentication.principal.nickName}" name="nickName" class="form-control" readonly>
     </div>
 
     <div class="input-group mb-3">
         <span class="input-group-text">이메일</span>
-        <input type="email" th:value="${auth.email}" name="email" class="form-control" readonly>
+        <input type="email" th:value="${#authentication.principal.email}" name="email" class="form-control" readonly>
     </div>
 
     <a th:href="@{/auth/modify}" class="text-decoration-none">


### PR DESCRIPTION
# Do-tori
# 🐛fix:  login,info,modify,delete fix

- 소셜로 로그인하면 auth/ info, modify 안되던 버그 수정
- 소셜로 로그인 할 때 pw 기본값 1234로 수정
- 소셜로 로그인 할 때 id 값을 email 값으로 자동 입력되게 수정
- info, mofify 에서 비밀번호가 노출되던 이슈 수정

![image](https://github.com/CheHyeonYeong/Do-tori/assets/57084218/0b0d0685-d632-48e2-849e-313fc3a85865)
![image](https://github.com/CheHyeonYeong/Do-tori/assets/57084218/aca60c1e-b661-4499-90a6-bdaf2046760f)
